### PR TITLE
adds support for `statusCode` 204

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -62,7 +62,7 @@ function request(settings, data, callback) {
 
 		res.on("end", function() {
 			if (res.statusCode === 204) {
-				return cb(null, response, meta);
+				return callback(null, response, meta);
 			}
 
 			if (res.statusCode >= 400) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -61,6 +61,10 @@ function request(settings, data, callback) {
 		});
 
 		res.on("end", function() {
+			if (res.statusCode === 204) {
+				return cb(null, response, meta);
+			}
+
 			if (res.statusCode >= 400) {
 				var message;
 				if (res.headers["content-type"].indexOf("json") !== -1) {


### PR DESCRIPTION
currently this throws a `JSON.parse` syntax error when no content is returned in the response. 

edit: sorry about the extra commit for a lame typo... I'm still messing around with other potential changes in a local clone
